### PR TITLE
Fix issues #21

### DIFF
--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -147,7 +147,12 @@ class Socket extends EventEmitter {
     if (EVENTS.contains(event)) {
       super.emit(event, data);
     } else {
-      List sendData = data == null ? [event] : [event, data];
+      List sendData = [event];
+      if (data is Iterable) {
+          sendData.addAll(data);
+      } else {
+          sendData.add(data);
+      }
 
       var packet = {
         'type': binary ? BINARY_EVENT : EVENT,


### PR DESCRIPTION
#21 Fixed for multiple arguments should be add into current array.

Before:
```
_socket.emit('get', [ 'product', 5 ]);

data = [ 'get', 'product,5' ];
```

After:
```
_socket.emit('get', [ 'product', 5 ]);

data = [ 'get', 'product', 5 ];
```