### PR TITLE
[HOTFIX] Change factor to 1 as any number higher cause an overflow

### DIFF
--- a/lib/src/manager.dart
+++ b/lib/src/manager.dart
@@ -553,7 +553,7 @@ class _Backoff {
   num _jitter;
   num attempts;
 
-  _Backoff({min = 100, max = 10000, jitter = 0, factor = 2})
+  _Backoff({min = 100, max = 10000, jitter = 0, factor = 1})
       : _ms = min,
         _max = max,
         _factor = factor {


### PR DESCRIPTION
There's a bug in the library, in which after around 54 retries, the WebSocket does stop trying reconnecting.

It does stop because of the backoff ms.

`var ms = _ms * Math.pow(_factor, this.attempts++);`

The real fix would be changing the duration method. This is a hotfix.