### PR TITLE
Fixbug for Backoff when many attempts: "UnsupportedError: Unsupported operation: Infinity or NaN toInt"

### DIFF
--- a/lib/src/manager.dart
+++ b/lib/src/manager.dart
@@ -529,7 +529,7 @@ class _Backoff {
   /// @api public
   ///
   num get duration {
-    var ms = _ms * math.pow(_factor, attempts++);
+    var ms = math.min(_ms * math.pow(_factor, attempts++), 1e100);
     if (_jitter > 0) {
       var rand = math.Random().nextDouble();
       var deviation = (rand * _jitter * ms).floor();


### PR DESCRIPTION
Hi thanks for the lib! For the backoff, when `jitter` is nonzero and there are many many attempts, the following error occurs:

```
UnsupportedError: Unsupported operation: Infinity or NaN toInt
  File "double.dart", line 219, in _Double.toInt
  File "double.dart", line 183, in _Double.floor
```

caused by the line of `var deviation = (rand * jitter * ms).floor();`, because `ms` is `Infinity` and floor cannot be called on it.

Thus I propose a fix to it :)