### PR TITLE
Allow sending an ack with multiple data items (making it consistent with emit)

### DIFF
--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -280,16 +280,25 @@ class Socket extends EventEmitter {
   /// @api private
   Function ack(id) {
     var sent = false;
-    return (_) {
+    return (dynamic data) {
       // prevent double callbacks
       if (sent) return;
       sent = true;
-      _logger.fine('sending ack $_');
+      _logger.fine('sending ack $data');
+
+      var sendData = <dynamic>[];
+      if (data is ByteBuffer || data is List<int>) {
+        sendData.add(data);
+      } else if (data is Iterable) {
+        sendData.addAll(data);
+      } else if (data != null) {
+        sendData.add(data);
+      }
 
       packet({
         'type': ACK,
         'id': id,
-        'data': [_]
+        'data': sendData
       });
     };
   }


### PR DESCRIPTION
This simple PR changes the `ack` function to use the same logic as `emit` when populating the `data` list. This allows to send an ack with more than one data items.

I find the ability to return multiple items quite useful. Moreover, having the same logic in `emit` and `ack` is what the user would expect, and makes the code consistent.