### PR TITLE
Fix missing parameter in socket event handler for addResponse in example

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -182,7 +182,7 @@ void connectAndListen(){
     });
 
     //When an event recieved from server, data is added to the stream
-    socket.on('event', (data) => streamSocket.addResponse);
+    socket.on('event', (data) => streamSocket.addResponse(data));
     socket.onDisconnect((_) => print('disconnect'));
 
 }


### PR DESCRIPTION
Description
This pull request addresses an issue in the example code for handling socket events in the StreamSocket class. Specifically, the code incorrectly assigns the event handler for incoming data without passing the necessary parameter to the addResponse method.

Changes Made:

Updated the socket event handler in the example code to properly pass the received data to the addResponse method.
Before:

```
socket.on('event', (data) => streamSocket.addResponse);
```
After:
```
socket.on('event', (data) => streamSocket.addResponse(data));
```
Reason for Change
The original code would not send any data to the stream, causing the StreamBuilder to receive no updates when an event occurred. By ensuring that the data parameter is passed to addResponse, this fix allows the application to correctly handle incoming socket messages and update the UI as expected.

Related Issue
Fixes #396 