### PR TITLE
Fix: #331 Emit Connect_error for Middleware Reject

### DIFF
--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -426,7 +426,7 @@ class Socket extends EventEmitter {
 
       case CONNECT_ERROR:
         destroy();
-        emitReserved('error', packet['data']);
+        emitReserved('connect_error', packet['data']);
         break;
     }
   }


### PR DESCRIPTION
I feel the ideal scenario should be emitting connect_error as per https://socket.io/docs/v4/client-api/#event-connect_error