### PR TITLE
fix: parseqs decode crash on key-only query params; add disableWithCredentials; expand tests

### DIFF
--- a/lib/src/darty.dart
+++ b/lib/src/darty.dart
@@ -69,6 +69,12 @@ class OptionBuilder {
     return this;
   }
 
+  /// Disable with credentials.
+  OptionBuilder disableWithCredentials() {
+    _opts['withCredentials'] = false;
+    return this;
+  }
+
   /// Whether to enable to create a new Manager instance.
   /// The default is false
   OptionBuilder enableForceNew() {

--- a/lib/src/engine/parseqs.dart
+++ b/lib/src/engine/parseqs.dart
@@ -35,7 +35,8 @@ Map decode(qs) {
   var pairs = qs.split('&');
   for (var i = 0, l = pairs.length; i < l; i++) {
     var pair = pairs[i].split('=');
-    qry[Uri.decodeComponent(pair[0])] = Uri.decodeComponent(pair[1]);
+    qry[Uri.decodeComponent(pair[0])] =
+        pair.length > 1 ? Uri.decodeComponent(pair[1]) : '';
   }
   return qry;
 }

--- a/test/option_builder_full_test.dart
+++ b/test/option_builder_full_test.dart
@@ -1,0 +1,232 @@
+import 'package:test/test.dart';
+import 'package:socket_io_client/src/darty.dart';
+
+void main() {
+  group('OptionBuilder', () {
+    test('build() returns empty map by default', () {
+      final opts = OptionBuilder().build();
+      expect(opts, isEmpty);
+    });
+
+    group('withCredentials', () {
+      test('enableWithCredentials sets withCredentials to true', () {
+        final opts = OptionBuilder().enableWithCredentials().build();
+        expect(opts['withCredentials'], isTrue);
+      });
+
+      test('disableWithCredentials sets withCredentials to false', () {
+        final opts = OptionBuilder()
+            .enableWithCredentials()
+            .disableWithCredentials()
+            .build();
+        expect(opts['withCredentials'], isFalse);
+      });
+    });
+
+    group('forceNew', () {
+      test('enableForceNew sets forceNew to true', () {
+        final opts = OptionBuilder().enableForceNew().build();
+        expect(opts['forceNew'], isTrue);
+      });
+
+      test('disableForceNew removes forceNew key', () {
+        final opts =
+            OptionBuilder().enableForceNew().disableForceNew().build();
+        expect(opts.containsKey('forceNew'), isFalse);
+      });
+    });
+
+    group('multiplex', () {
+      test('enableMultiplex sets multiplex to true', () {
+        final opts = OptionBuilder().enableMultiplex().build();
+        expect(opts['multiplex'], isTrue);
+      });
+
+      test('disableMultiplex removes multiplex key', () {
+        final opts =
+            OptionBuilder().enableMultiplex().disableMultiplex().build();
+        expect(opts.containsKey('multiplex'), isFalse);
+      });
+    });
+
+    group('trailingSlash', () {
+      test('enableAddTrailingSlash sets addTrailingSlash to true', () {
+        final opts = OptionBuilder().enableAddTrailingSlash().build();
+        expect(opts['addTrailingSlash'], isTrue);
+      });
+
+      test('disableAddTrailingSlash sets addTrailingSlash to false', () {
+        final opts = OptionBuilder().disableAddTrailingSlash().build();
+        expect(opts['addTrailingSlash'], isFalse);
+      });
+    });
+
+    group('autoConnect', () {
+      test('disableAutoConnect sets autoConnect to false', () {
+        final opts = OptionBuilder().disableAutoConnect().build();
+        expect(opts['autoConnect'], isFalse);
+      });
+
+      test('enableAutoConnect removes autoConnect key (defaults to true)', () {
+        final opts = OptionBuilder()
+            .disableAutoConnect()
+            .enableAutoConnect()
+            .build();
+        expect(opts.containsKey('autoConnect'), isFalse);
+      });
+    });
+
+    group('reconnection', () {
+      test('disableReconnection sets reconnection to false', () {
+        final opts = OptionBuilder().disableReconnection().build();
+        expect(opts['reconnection'], isFalse);
+      });
+
+      test('enableReconnection removes reconnection key (defaults to true)', () {
+        final opts = OptionBuilder()
+            .disableReconnection()
+            .enableReconnection()
+            .build();
+        expect(opts.containsKey('reconnection'), isFalse);
+      });
+
+      test('setReconnectionAttempts stores the value', () {
+        final opts = OptionBuilder().setReconnectionAttempts(5).build();
+        expect(opts['reconnectionAttempts'], equals(5));
+      });
+
+      test('setReconnectionDelay stores the value', () {
+        final opts = OptionBuilder().setReconnectionDelay(2000).build();
+        expect(opts['reconnectionDelay'], equals(2000));
+      });
+
+      test('setReconnectionDelayMax stores the value', () {
+        final opts = OptionBuilder().setReconnectionDelayMax(10000).build();
+        expect(opts['reconnectionDelayMax'], equals(10000));
+      });
+
+      test('setRandomizationFactor stores the value', () {
+        final opts = OptionBuilder().setRandomizationFactor(0.3).build();
+        expect(opts['randomizationFactor'], equals(0.3));
+      });
+    });
+
+    group('timeout', () {
+      test('setTimeout stores the value', () {
+        final opts = OptionBuilder().setTimeout(5000).build();
+        expect(opts['timeout'], equals(5000));
+      });
+
+      test('setAckTimeout stores the value', () {
+        final opts = OptionBuilder().setAckTimeout(3000).build();
+        expect(opts['ackTimeout'], equals(3000));
+      });
+    });
+
+    group('path and query', () {
+      test('setPath stores the value', () {
+        final opts = OptionBuilder().setPath('/custom').build();
+        expect(opts['path'], equals('/custom'));
+      });
+
+      test('setQuery stores the map', () {
+        final query = {'token': 'abc123'};
+        final opts = OptionBuilder().setQuery(query).build();
+        expect(opts['query'], equals(query));
+      });
+    });
+
+    group('transports', () {
+      test('setTransports stores the list', () {
+        final opts =
+            OptionBuilder().setTransports(['websocket']).build();
+        expect(opts['transports'], equals(['websocket']));
+      });
+
+      test('setUpgrade stores the value', () {
+        final opts = OptionBuilder().setUpgrade(false).build();
+        expect(opts['upgrade'], isFalse);
+      });
+
+      test('setRememberUpgrade stores the value', () {
+        final opts = OptionBuilder().setRememberUpgrade(true).build();
+        expect(opts['rememberUpgrade'], isTrue);
+      });
+    });
+
+    group('headers and auth', () {
+      test('setExtraHeaders stores the map', () {
+        final headers = {'Authorization': 'Bearer token'};
+        final opts = OptionBuilder().setExtraHeaders(headers).build();
+        expect(opts['extraHeaders'], equals(headers));
+      });
+
+      test('setAuth stores the map', () {
+        final auth = {'token': 'secret'};
+        final opts = OptionBuilder().setAuth(auth).build();
+        expect(opts['auth'], equals(auth));
+      });
+
+      test('setAuthFn stores the callback', () {
+        void authFn(void Function(Map) cb) => cb({'token': 'x'});
+        final opts = OptionBuilder().setAuthFn(authFn).build();
+        expect(opts['auth'], isA<Function>());
+      });
+    });
+
+    group('miscellaneous', () {
+      test('setProtocols stores the list', () {
+        final opts =
+            OptionBuilder().setProtocols(['wss']).build();
+        expect(opts['protocols'], equals(['wss']));
+      });
+
+      test('setTimestampParam stores the value', () {
+        final opts = OptionBuilder().setTimestampParam('ts').build();
+        expect(opts['timestampParam'], equals('ts'));
+      });
+
+      test('setTimestampRequests stores the value', () {
+        final opts = OptionBuilder().setTimestampRequests(false).build();
+        expect(opts['timestampRequests'], isFalse);
+      });
+
+      test('setRetries stores the value', () {
+        final opts = OptionBuilder().setRetries(3).build();
+        expect(opts['retries'], equals(3));
+      });
+
+      test('setForceBase64 stores the value', () {
+        final opts = OptionBuilder().setForceBase64(true).build();
+        expect(opts['forceBase64'], isTrue);
+      });
+
+      test('setTransportOptions stores the map', () {
+        final transportOpts = {'websocket': {'timeout': 5000}};
+        final opts =
+            OptionBuilder().setTransportOptions(transportOpts).build();
+        expect(opts['transportOptions'], equals(transportOpts));
+      });
+    });
+
+    group('builder chaining', () {
+      test('multiple options can be chained together', () {
+        final opts = OptionBuilder()
+            .disableAutoConnect()
+            .setPath('/my-socket')
+            .setTransports(['websocket'])
+            .setReconnectionAttempts(3)
+            .setTimeout(10000)
+            .setExtraHeaders({'X-Custom': 'header'})
+            .build();
+
+        expect(opts['autoConnect'], isFalse);
+        expect(opts['path'], equals('/my-socket'));
+        expect(opts['transports'], equals(['websocket']));
+        expect(opts['reconnectionAttempts'], equals(3));
+        expect(opts['timeout'], equals(10000));
+        expect(opts['extraHeaders'], equals({'X-Custom': 'header'}));
+      });
+    });
+  });
+}

--- a/test/parseqs_test.dart
+++ b/test/parseqs_test.dart
@@ -1,0 +1,73 @@
+import 'package:test/test.dart';
+import 'package:socket_io_client/src/engine/parseqs.dart';
+
+void main() {
+  group('parseqs.encode', () {
+    test('encodes a simple map into a query string', () {
+      expect(encode({'foo': 'bar'}), equals('foo=bar'));
+    });
+
+    test('encodes multiple key-value pairs with & separator', () {
+      final result = encode({'a': '1', 'b': '2'});
+      expect(result, contains('a=1'));
+      expect(result, contains('b=2'));
+      expect(result, contains('&'));
+    });
+
+    test('percent-encodes special characters in keys and values', () {
+      expect(encode({'hello world': 'foo bar'}), equals('hello%20world=foo%20bar'));
+    });
+
+    test('encodes an empty map into an empty string', () {
+      expect(encode({}), equals(''));
+    });
+
+    test('encodes numeric values as strings', () {
+      expect(encode({'port': 3000}), equals('port=3000'));
+    });
+  });
+
+  group('parseqs.decode', () {
+    test('decodes a simple query string into a map', () {
+      final result = decode('foo=bar');
+      expect(result['foo'], equals('bar'));
+    });
+
+    test('decodes multiple key-value pairs', () {
+      final result = decode('a=1&b=2&c=3');
+      expect(result['a'], equals('1'));
+      expect(result['b'], equals('2'));
+      expect(result['c'], equals('3'));
+    });
+
+    test('decodes percent-encoded characters', () {
+      final result = decode('hello%20world=foo%20bar');
+      expect(result['hello world'], equals('foo bar'));
+    });
+
+    test('returns an empty map for an empty string', () {
+      expect(decode(''), isEmpty);
+    });
+
+    test('handles a key-only param without throwing', () {
+      // Previously threw RangeError on pair[1]
+      final result = decode('flag');
+      expect(result['flag'], equals(''));
+    });
+
+    test('handles mixed normal and key-only params without throwing', () {
+      final result = decode('a=1&flag&c=3');
+      expect(result['a'], equals('1'));
+      expect(result['flag'], equals(''));
+      expect(result['c'], equals('3'));
+    });
+
+    test('encode and decode round-trip preserves values', () {
+      final original = {'key': 'value', 'num': '42'};
+      final encoded = encode(original);
+      final decoded = decode(encoded);
+      expect(decoded['key'], equals('value'));
+      expect(decoded['num'], equals('42'));
+    });
+  });
+}


### PR DESCRIPTION
## What this PR does

### Bug fix — `parseqs.decode()` crash on key-only query params
`decode("flag")` and `decode("a=1&flag&c=3")` threw a `RangeError`
because `pair[1]` was accessed unconditionally after `split('=')`.
Key-only params are valid URL syntax. Fixed by guarding on `pair.length`,
returning `''` as the value (matches browser behaviour).

### API fix — `OptionBuilder.disableWithCredentials()`
`enableWithCredentials()` existed but had no counterpart. Callers
could not explicitly opt back out when chaining. Added
`disableWithCredentials()` to complete the symmetric pattern already
used by `forceNew`, `multiplex`, `autoConnect`, and `reconnection`.

### Tests
- `test/parseqs_test.dart` — 12 cases for `encode` and `decode`,
  including the key-only crash case and a round-trip test.
- `test/option_builder_full_test.dart` — 31 cases covering every
  `OptionBuilder` method grouped by category, plus a chaining test.

Test count: **8 → 54**, all passing.