### PR TITLE
fix: dispose() does not clear _anyListeners and _anyOutgoingListeners

### DIFF
--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -615,6 +615,8 @@ class Socket extends EventEmitter {
   void dispose() {
     disconnect();
     clearListeners();
+    _anyListeners.clear();
+    _anyOutgoingListeners.clear();
   }
 
   ///

--- a/test/socket_dispose_test.dart
+++ b/test/socket_dispose_test.dart
@@ -1,0 +1,53 @@
+import 'package:test/test.dart';
+import 'package:socket_io_client/src/manager.dart';
+import 'package:socket_io_client/src/socket.dart';
+
+void main() {
+  group('Socket.dispose()', () {
+    late Socket socket;
+
+    setUp(() {
+      final manager = Manager(
+        uri: 'http://localhost:3000',
+        options: {'autoConnect': false},
+      );
+      socket = Socket(manager, '/', {'autoConnect': false});
+    });
+
+    test('clears onAny listeners registered via onAny()', () {
+      socket.onAny((event, data) {});
+      socket.onAny((event, data) {});
+      expect(socket.listenersAny(), hasLength(2));
+
+      socket.dispose();
+
+      expect(socket.listenersAny(), isEmpty);
+    });
+
+    test('clears onAnyOutgoing listeners registered via onAnyOutgoing()', () {
+      socket.onAnyOutgoing((event, data) {});
+      expect(socket.listenersAnyOutgoing(), hasLength(1));
+
+      socket.dispose();
+
+      expect(socket.listenersAnyOutgoing(), isEmpty);
+    });
+
+    test('clears both onAny and onAnyOutgoing together', () {
+      socket.onAny((event, data) {});
+      socket.onAnyOutgoing((event, data) {});
+
+      socket.dispose();
+
+      expect(socket.listenersAny(), isEmpty);
+      expect(socket.listenersAnyOutgoing(), isEmpty);
+    });
+
+    test('dispose() is idempotent — safe to call multiple times', () {
+      socket.onAny((event, data) {});
+      socket.dispose();
+      expect(() => socket.dispose(), returnsNormally);
+      expect(socket.listenersAny(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #430

## Problem
`dispose()` calls `clearListeners()` which only clears the parent
`EventEmitter` listener maps. The Socket-specific `_anyListeners`
(registered via `onAny()`) and `_anyOutgoingListeners` (registered via
`onAnyOutgoing()`) were never cleared, leaking handlers after the
socket was disposed.

This directly contradicts the doc comment on `dispose()` which states
it should *"clear all the event listeners"*.

## Fix
Added `_anyListeners.clear()` and `_anyOutgoingListeners.clear()` to
`dispose()`.

## Tests
Added `test/socket_dispose_test.dart` with 4 cases:
- clears `onAny` listeners
- clears `onAnyOutgoing` listeners
- clears both together
- safe to call `dispose()` multiple times (idempotent)
