### PR TITLE
fix: _drainQueue crashes with "Bad state: No element" when event has no args

### DIFF
--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -285,7 +285,7 @@ class Socket extends EventEmitter {
     flags = packet['flags'];
     var args = packet['args'] as List;
     final evt = args.removeAt(0);
-    final ack = args.last is Function ? args.removeLast() : null;
+    final ack = args.isNotEmpty && args.last is Function ? args.removeLast() : null;
     emitWithAck(evt, args, ack: ack);
   }
 

--- a/test/socket_drain_queue_test.dart
+++ b/test/socket_drain_queue_test.dart
@@ -1,0 +1,41 @@
+import 'package:test/test.dart';
+import 'package:socket_io_client/src/manager.dart';
+import 'package:socket_io_client/src/socket.dart';
+
+void main() {
+  group('Socket._drainQueue()', () {
+    late Socket socket;
+
+    setUp(() {
+      final manager = Manager(
+        uri: 'http://localhost:3000',
+        options: {'autoConnect': false, 'retries': 3},
+      );
+      socket = Socket(manager, '/', {'autoConnect': false});
+    });
+
+    test('does not throw when queued event has no arguments', () {
+      // Simulates emitting an event with no data while retries is set.
+      // Previously crashed with "Bad state: No element" because _drainQueue
+      // called args.last unconditionally on an empty list after removeAt(0).
+      expect(
+        () => socket.emitWithAck('ping', null),
+        returnsNormally,
+      );
+    });
+
+    test('does not throw when queued event has data but no ack callback', () {
+      expect(
+        () => socket.emitWithAck('chat', 'hello'),
+        returnsNormally,
+      );
+    });
+
+    test('does not throw when queued event has an ack callback', () {
+      expect(
+        () => socket.emitWithAck('chat', 'hello', ack: (response) {}),
+        returnsNormally,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #436

## Problem
`_drainQueue()` called `args.last` unconditionally after stripping the
event name with `args.removeAt(0)`. When an event was emitted with no
arguments while `retries` was configured (routing through `_addToQueue`),
`args` became an empty list and `args.last` threw:

> Unhandled exception: Bad state: No element

## Fix
Added an `args.isNotEmpty` guard before accessing `args.last`.

## Tests
Added `test/socket_drain_queue_test.dart` with 3 cases:
- emit with no arguments (the crash case)
- emit with data but no ack callback
- emit with data and an ack callback
