### PR TITLE
fix: handle empty ack payload when timeout flag is set

### DIFF
--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -310,12 +310,10 @@ class Socket extends EventEmitter {
       ack(Exception("operation has timed out"));
     });
 
-    acks[sid] = (args) {
+    acks[sid] = ([args]) {
       timer.cancel();
-      Function.apply(ack, [
-        null,
-        ...(args is List ? args : [args])
-      ]);
+      final list = args is List ? args : (args == null ? <dynamic>[] : [args]);
+      Function.apply(ack, [null, ...list]);
     };
   }
 


### PR DESCRIPTION
## Summary
Fixes `NoSuchMethodError` thrown by `Socket.onack` when an emit uses a `timeout` (or `ackTimeout`) and the server replies with an ack carrying **no arguments**.

## Stack trace (before fix)
```
NoSuchMethodError: Closure call with mismatched arguments:
  function 'Socket._registerAckCallback.<anonymous closure>'
Receiver: Closure: (dynamic) => Null
Tried calling: Socket._registerAckCallback.<anonymous closure>()
Found:         Socket._registerAckCallback.<anonymous closure>(dynamic) => Null

#4  Socket.onack    (package:socket_io_client/src/socket.dart:518:18)
#5  Socket.onpacket (package:socket_io_client/src/socket.dart:420:9)
```

## Root cause
In `lib/src/socket.dart`, `_registerAckCallback` wraps the user's ack when a timeout is set (lines 312‚Äì318):

```dart
acks[sid] = (args) {                 // one REQUIRED positional arg
  timer.cancel();
  Function.apply(ack, [
    null,
    ...(args is List ? args : [args])
  ]);
};
```

`Socket.onack` (lines 508‚Äì523) then forwards whatever the server sent:

```dart
var args = packet['data'] as List;
if (args.length > 1) {
  Function.apply(ack, [args]);
} else {
  Function.apply(ack, args);   // args may be [] ‚Üí 0-arg call into 1-arg wrapper
}
```

When the server emits `ack()` with no payload, `args` is `[]` and `Function.apply(wrapper, [])` throws because the wrapper requires one positional arg. This is reachable from any caller of `emitWithAckAsync`, or any `socket.timeout(x).emit(...)` with an ack.

## Fix
Make the wrapper's positional argument optional and normalize the argument list before forwarding:

```dart
acks[sid] = ([args]) {
  timer.cancel();
  final list = args is List ? args : (args == null ? <dynamic>[] : [args]);
  Function.apply(ack, [null, ...list]);
};
```

Behavior for non-empty acks is unchanged; empty acks now complete normally instead of crashing.

## Reproduction
**Client (Dart):**
```dart
socket.timeout(5000).emitWithAckAsync('ping', {}).then(print);
```

**Server (Node, socket.io):**
```js
io.on('connection', (s) => {
  s.on('ping', (data, ack) => ack()); // ack invoked with no args
});
```

- Before: client throws the `NoSuchMethodError` above on receipt of the ack packet.
- After: the `Future` returned by `emitWithAckAsync` completes with `null`.

## Risk / compatibility
- No public API change ‚Äî `acks[sid]` is internal and only invoked by `Socket.onack`, which already passes one of `[]`, `[arg]`, or `[List args]`. All three are supported.
- Minimal, localized change; no test changes required to keep existing behavior.
